### PR TITLE
Update AutoSuggest.js

### DIFF
--- a/src/AutoSuggest.js
+++ b/src/AutoSuggest.js
@@ -25,7 +25,7 @@ function splitValue(originalValue, cursorPosition, trigger) {
 
 function getCharHeight(...elements) {
     return Math.max(...elements.map(element => (
-        parseFloat(getComputedStyle(element, 'line-height'))
+        return (!isNaN(parseFloat(getComputedStyle(element, 'line-height'))) ? parseFloat(getComputedStyle(element, 'line-height')) : parseFloat(getComputedStyle(element, 'font-size')));
     )));
 }
 


### PR DESCRIPTION
getComputedStyle(element, 'line-height') was returning 'normal' thus NaN and placing the .top position incorrectly at zero. Fixed by defaulting to font-height if line-height isn't numeric.